### PR TITLE
Bugfix/pagination-searching-movie

### DIFF
--- a/src/js/movieSearch.js
+++ b/src/js/movieSearch.js
@@ -1,6 +1,7 @@
 import apiService from "./apiService";
 import renderGallery from "./templates/movieGallary";
-import renderPaginationButtons from "./apiService";
+import { renderPaginationButtons } from "./pagination";
+import { resetPagination } from "./pagination";
 import NProgress from 'nprogress';
 import 'nprogress/nprogress.css';
 
@@ -24,7 +25,9 @@ export default function onSearchButton (e) {
         } else {
             searchErrMsgEl.style.display = "none";
             clearGallery();
+            resetPagination();
             renderGallery(data.results, allGenres);
+            renderPaginationButtons(data.total_pages, data.page);
 
             NProgress.done();
             

--- a/src/js/pagination.js
+++ b/src/js/pagination.js
@@ -120,5 +120,9 @@ function resetPage() {
     cardsContainer.innerHTML = '';
 }
 
-export { renderPaginationButtons };
+function resetPagination() {
+    paginationList.innerHTML = '';
+}
 
+export { renderPaginationButtons };
+export { resetPagination };


### PR DESCRIPTION
Коли при фетчі приходили дані з властивістю total_pages: 1, на сторінці пагінація залишалась з фетчу трендових фільмів. Тобто не стиралась. 
Додала reset пагінації в movieSearch.js
